### PR TITLE
Signals

### DIFF
--- a/base.h
+++ b/base.h
@@ -7,9 +7,9 @@
  * @brief Includes all headers in the base library
  * @version 0.1
  * @date 2019-09-06
- * 
+ *
  * @copyright Copyright (c) 2019
- * 
+ *
  */
 
 #include "OS/base-OS.h"
@@ -18,6 +18,7 @@
 #include "io/base-io.h"
 #include "lists/base-lists.h"
 #include "references/base-references.h"
+#include "startup/base_onStartup.h"
 #include "unused/base-unused.h"
 
 #include "banned/base-banned.h"

--- a/signal-handler/base-signal-handler.c
+++ b/signal-handler/base-signal-handler.c
@@ -10,6 +10,41 @@
  */
 #include "base-signal-handler.h"
 
+/**
+ * @brief Register a signal handler for a particular signal, failing appropriately
+ *
+ * @param sig The signal for the new handler
+ * @param handler The function to handle the signal
+ */
+static void registerSignal(int sig, void (*handler)(int));
+
+/**
+ * @brief Default handler for signals which require an immediate, ungracious exit
+ *
+ * @param signal The signal code
+ */
+static void abortingSignalHandler(int signal);
+
+/**
+ * @brief Default handler for signals which graciously cause an exit
+ *
+ * @param signal The signal code
+ */
+static void graciousSignalHandler(int signal);
+
+/**
+ * @brief Print a stack-trace at the current point of execution
+ */
+static void printStackTrace();
+
+/**
+ * @brief Obtain a string representation of a signal
+ *
+ * @param signal The code of the signal to convert
+ * @return char* A string representation of the signal
+ */
+static char* sigToA(int signal);
+
 int g_base_callStackSize = 25;
 
 void base_registerSignals(void)
@@ -18,7 +53,7 @@ void base_registerSignals(void)
 	registerSignal(SIGINT, graciousSignalHandler);
 }
 
-void registerSignal(int sig, void (*handler)(int sig))
+static void registerSignal(int sig, void (*handler)(int))
 {
 	if (signal(sig, handler))
 	{
@@ -27,16 +62,16 @@ void registerSignal(int sig, void (*handler)(int sig))
 	}
 }
 
-void abortingSignalHandler(int sig)
+static void abortingSignalHandler(int sig)
 {
 	fprintf(stderr, "Received signal %s\n", sigToA(sig));
 	printStackTrace();
 	abort();
 }
 
-void graciousSignalHandler(int UNUSED(signal)) { exit(EXIT_FAILURE); }
+static void graciousSignalHandler(int UNUSED(signal)) { exit(EXIT_FAILURE); }
 
-void printStackTrace()
+static void printStackTrace()
 {
 	fprintf(stderr, "Stack trace:\n");
 	void* callStack[g_base_callStackSize];
@@ -44,7 +79,7 @@ void printStackTrace()
 	backtrace_symbols_fd(callStack, size, STDERR_FILENO);
 }
 
-char* sigToA(int signal)
+static char* sigToA(int signal)
 {
 	if (signal == SIGSEGV)
 	{

--- a/signal-handler/base-signal-handler.c
+++ b/signal-handler/base-signal-handler.c
@@ -1,0 +1,58 @@
+/**
+ * @file base-signal-handler.c
+ * @author Ed Jones (ed@kcza.net)
+ * @brief Defines a default signal handler
+ * @version 0.1
+ * @date 2019-09-07
+ *
+ * @copyright Copyright (c) 2019
+ *
+ */
+#include "base-signal-handler.h"
+
+int g_base_callStackSize = 25;
+
+void base_registerSignals(void)
+{
+	printf("Initialising Emperor\n");
+	signal(SIGINT, signalHandler);
+	signal(SIGSEGV, signalHandler);
+}
+
+void signalHandler(int signal)
+{
+	void* callStack[g_base_callStackSize];
+	size_t size = backtrace(callStack, g_base_callStackSize);
+
+	char* rep = sigToA(signal);
+	fprintf(stderr, "\nReceived signal %s!\n", rep);
+	fprintf(stderr, "Printing stack trace\n");
+	backtrace_symbols_fd(callStack, size, STDERR_FILENO);
+	fprintf(stderr, "Ejecting core\n");
+	exit(EXIT_FAILURE);
+}
+
+char* sigToA(int signal)
+{
+	if (signal == SIGSEGV)
+	{
+		return "SIGSEGV";
+	}
+	else if (signal == SIGINT)
+	{
+		return "SIGINT";
+	}
+	else
+	{
+		const int signalStringLength = 6;
+		char* str                    = (char*)malloc(signalStringLength * sizeof(char));
+		int pos                      = signalStringLength - 2;
+		while (signal > 0 && pos >= 0)
+		{
+			str[pos--] = signal % 10;
+			signal /= 10;
+		}
+		str[signalStringLength - 1] = '\0';
+		return str;
+	}
+}

--- a/signal-handler/base-signal-handler.h
+++ b/signal-handler/base-signal-handler.h
@@ -1,0 +1,45 @@
+#ifndef BASE_SIGNAL_HANDLER_H_
+#define BASE_SIGNAL_HANDLER_H_
+
+/**
+ * @file base-signal-handler.h
+ * @author Ed Jones (ed@kcza.net)
+ * @brief Provides prototypes for a default signal handler
+ * @version 0.1
+ * @date 2019-09-07
+ *
+ * @copyright Copyright (c) 2019
+ *
+ */
+
+#include <execinfo.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include "../banned/base-banned.h"
+
+/**
+ * @brief The maximum depth of call stack which may be reported
+ */
+extern int g_base_callStackSize;
+
+void base_registerSignals(void);
+
+/**
+ * @brief Default handler for signals
+ *
+ * @param signal The signal code
+ */
+void signalHandler(int signal);
+
+/**
+ * @brief Obtain a string representation of a signal
+ *
+ * @param signal The code of the signal to convert
+ * @return char* A string representation of the signal
+ */
+char* sigToA(int signal);
+
+#endif /* BASE_SIGNAL_HANDLER_H_ */

--- a/signal-handler/base-signal-handler.h
+++ b/signal-handler/base-signal-handler.h
@@ -31,39 +31,4 @@ extern int g_base_callStackSize;
  */
 void base_registerSignals(void);
 
-/**
- * @brief Register a signal handler for a particular signal, failing appropriately
- *
- * @param sig The signal for the new handler
- * @param handler The function to handle the signal
- */
-void registerSignal(int sig, void (*handler)(int));
-
-/**
- * @brief Default handler for signals which require an immediate, ungracious exit
- *
- * @param signal The signal code
- */
-void abortingSignalHandler(int signal);
-
-/**
- * @brief Default handler for signals which graciously cause an exit
- *
- * @param signal The signal code
- */
-void graciousSignalHandler(int signal);
-
-/**
- * @brief Print a stack-trace at the current point of execution
- */
-void printStackTrace();
-
-/**
- * @brief Obtain a string representation of a signal
- *
- * @param signal The code of the signal to convert
- * @return char* A string representation of the signal
- */
-char* sigToA(int signal);
-
 #endif /* BASE_SIGNAL_HANDLER_H_ */

--- a/signal-handler/base-signal-handler.h
+++ b/signal-handler/base-signal-handler.h
@@ -19,20 +19,44 @@
 #include <unistd.h>
 
 #include "../banned/base-banned.h"
+#include "../unused/base-unused.h"
 
 /**
  * @brief The maximum depth of call stack which may be reported
  */
 extern int g_base_callStackSize;
 
+/**
+ * @brief Register the default signal handlers.
+ */
 void base_registerSignals(void);
 
 /**
- * @brief Default handler for signals
+ * @brief Register a signal handler for a particular signal, failing appropriately
+ *
+ * @param sig The signal for the new handler
+ * @param handler The function to handle the signal
+ */
+void registerSignal(int sig, void (*handler)(int));
+
+/**
+ * @brief Default handler for signals which require an immediate, ungracious exit
  *
  * @param signal The signal code
  */
-void signalHandler(int signal);
+void abortingSignalHandler(int signal);
+
+/**
+ * @brief Default handler for signals which graciously cause an exit
+ *
+ * @param signal The signal code
+ */
+void graciousSignalHandler(int signal);
+
+/**
+ * @brief Print a stack-trace at the current point of execution
+ */
+void printStackTrace();
 
 /**
  * @brief Obtain a string representation of a signal

--- a/startup/base_onExit.c
+++ b/startup/base_onExit.c
@@ -4,11 +4,11 @@
  * @brief Provides functions to enable Emperor to exit under normal conditions
  * @version 0.1
  * @date 2019-09-07
- * 
+ *
  * @copyright Copyright (c) 2019
- * 
+ *
  */
 
 #include "base_onExit.h"
 
-void base_exitEmperor(void) { printf("Exiting Emperor\n"); }
+void base_exitEmperor(void) {}

--- a/startup/base_onExit.c
+++ b/startup/base_onExit.c
@@ -1,3 +1,14 @@
+/**
+ * @file base_onExit.c
+ * @author Ed Jones (ed@kcza.net)
+ * @brief Provides functions to enable Emperor to exit under normal conditions
+ * @version 0.1
+ * @date 2019-09-07
+ * 
+ * @copyright Copyright (c) 2019
+ * 
+ */
+
 #include "base_onExit.h"
 
 void base_exitEmperor(void) { printf("Exiting Emperor\n"); }

--- a/startup/base_onExit.c
+++ b/startup/base_onExit.c
@@ -1,0 +1,3 @@
+#include "base_onExit.h"
+
+void base_exitEmperor(void) { printf("Exiting Emperor\n"); }

--- a/startup/base_onExit.h
+++ b/startup/base_onExit.h
@@ -1,6 +1,17 @@
 #ifndef BASE_ONEXIT_H_
 #define BASE_ONEXIT_H_
 
+/**
+ * @file base_onExit.h
+ * @author Ed Jones (ed@kcza.net)
+ * @brief Provides prototypes for Emperor exit handlers under normal conditions
+ * @version 0.1
+ * @date 2019-09-07
+ *
+ * @copyright Copyright (c) 2019
+ *
+ */
+
 #include <stdio.h>
 
 void base_exitEmperor(void);

--- a/startup/base_onExit.h
+++ b/startup/base_onExit.h
@@ -1,0 +1,8 @@
+#ifndef BASE_ONEXIT_H_
+#define BASE_ONEXIT_H_
+
+#include <stdio.h>
+
+void base_exitEmperor(void);
+
+#endif /* BASE_ONEXIT_H_ */

--- a/startup/base_onStartup.c
+++ b/startup/base_onStartup.c
@@ -10,11 +10,11 @@
  */
 #include "base_onStartup.h"
 
-static bool startupComplete = false;
+static bool g_startupComplete = false;
 
 void base_initEmperor(void)
 {
-	if (startupComplete)
+	if (g_startupComplete)
 	{
 		fprintf(stderr, "Emperor setup can only be performed once");
 		exit(EXIT_FAILURE);
@@ -23,5 +23,5 @@ void base_initEmperor(void)
 	base_registerSignals();
 	atexit(base_exitEmperor);
 
-	startupComplete = true;
+	g_startupComplete = true;
 }

--- a/startup/base_onStartup.c
+++ b/startup/base_onStartup.c
@@ -10,4 +10,18 @@
  */
 #include "base_onStartup.h"
 
-void base_initEmperor(void) { base_registerSignals(); }
+static bool startupComplete = false;
+
+void base_initEmperor(void)
+{
+	if (startupComplete)
+	{
+		fprintf(stderr, "Emperor setup can only be performed once");
+		exit(EXIT_FAILURE);
+	}
+
+	base_registerSignals();
+	atexit(base_exitEmperor);
+
+	startupComplete = true;
+}

--- a/startup/base_onStartup.c
+++ b/startup/base_onStartup.c
@@ -1,3 +1,13 @@
+/**
+ * @file base_onStartup.c
+ * @author Ed Jones (ed@kcza.net)
+ * @brief Provides functions to call at the start of every Emperor program
+ * @version 0.1
+ * @date 2019-09-07
+ *
+ * @copyright Copyright (c) 2019
+ *
+ */
 #include "base_onStartup.h"
 
 void base_initEmperor(void) { base_registerSignals(); }

--- a/startup/base_onStartup.c
+++ b/startup/base_onStartup.c
@@ -1,0 +1,3 @@
+#include "base_onStartup.h"
+
+void base_initEmperor(void) { base_registerSignals(); }

--- a/startup/base_onStartup.h
+++ b/startup/base_onStartup.h
@@ -1,6 +1,17 @@
 #ifndef BASE_ONSTARTUP_H_
 #define BASE_ONSTARTUP_H_
 
+/**
+ * @file base_onStartup.h
+ * @author Ed Jones (ed@kcza.net)
+ * @brief Provides prototypes for functions called when Emperor starts up
+ * @version 0.1
+ * @date 2019-09-07
+ *
+ * @copyright Copyright (c) 2019
+ *
+ */
+
 #include "../signal-handler/base-signal-handler.h"
 
 void base_initEmperor(void);

--- a/startup/base_onStartup.h
+++ b/startup/base_onStartup.h
@@ -13,6 +13,10 @@
  */
 
 #include "../signal-handler/base-signal-handler.h"
+#include "base_onExit.h"
+#include <stdbool.h>
+
+static bool startupComplete;
 
 void base_initEmperor(void);
 

--- a/startup/base_onStartup.h
+++ b/startup/base_onStartup.h
@@ -16,8 +16,6 @@
 #include "base_onExit.h"
 #include <stdbool.h>
 
-static bool startupComplete;
-
 void base_initEmperor(void);
 
 #endif /* BASE_ONSTARTUP_H_ */

--- a/startup/base_onStartup.h
+++ b/startup/base_onStartup.h
@@ -1,0 +1,8 @@
+#ifndef BASE_ONSTARTUP_H_
+#define BASE_ONSTARTUP_H_
+
+#include "../signal-handler/base-signal-handler.h"
+
+void base_initEmperor(void);
+
+#endif /* BASE_ONSTARTUP_H_ */


### PR DESCRIPTION
Created signal handlers and functions to be called before and after an Emperor program has run.

A call to `base_initEmperor()` should be the first line of any compiled Emperor program---this handles the above.